### PR TITLE
Convert Pick List modifier to Dropdown

### DIFF
--- a/templates/components/products/options/product-list.html
+++ b/templates/components/products/options/product-list.html
@@ -1,4 +1,4 @@
-<div class="form-field" data-product-attribute="product-list" role="radiogroup" aria-labelledby="product-list-label">
+<div class="form-field" data-product-attribute="set-select" role="listbox" aria-labelledby="product-list-label">
     <label class="form-label form-label--alternate form-label--inlineSmall" id="product-list-label">
         {{display_name}}:
         <span data-option-value></span>
@@ -6,67 +6,28 @@
         {{> components/common/requireness-msg}}
     </label>
 
-    {{#if values.0.image}}
-        <ul class="productOptions-list">
-            {{#unless required}}
-                <li class="productOptions-list-item">
-                    <input class="form-radio"
-                           type="radio"
-                           name="attribute[{{id}}]"
-                           value=""
-                           id="attribute_productlist_{{id}}_none"
-                           checked="{{#if defaultValue '==' ''}}checked{{/if}}">
-                    <label class="form-label" for="attribute_productlist_{{id}}_none">{{lang 'products.none'}}</label>
-                </li>
-            {{/unless}}
-            {{#each values}}
-                <li class="productOptions-list-item" data-product-attribute-value="{{id}}">
-                    {{#if image}}
-                        <figure class="productOptions-list-item-figure">
-                            {{> components/common/responsive-img
-                                image=image
-                                class="productOptions-list-item-image"
-                                lazyload='lazyload+lqip'
-                            }}
-                        </figure>
-                    {{/if}}
-                    <div class="productOptions-list-item-content">
-                        <input
-                            class="form-radio"
-                            type="radio"
-                            name="attribute[{{../id}}]"
-                            value="{{id}}"
-                            id="attribute_productlist_{{../id}}_{{id}}"
-                            {{#if selected}}
-                                checked
-                                data-default
-                            {{/if}}
-                            {{#if ../required}}required{{/if}}>
-                        <label data-product-attribute-value="{{id}}" class="form-label" for="attribute_productlist_{{../id}}_{{id}}">{{label}}</label>
-                    </div>
-                </li>
-            {{/each}}
-        </ul>
-    {{else}}
+    <select class="form-select form-select--small" name="attribute[{{this.id}}]" id="attribute_select_{{id}}" {{#if required}}required{{/if}}>
+        <option value="">{{lang 'products.choose_options'}}</option>
         {{#unless required}}
-        <input class="form-radio"
-               type="radio"
-               name="attribute[{{id}}]"
-               value="0"
-               id="attribute_productlist_0_{{id}}"
-               {{#if defaultValue '==' 0}}checked{{/if}}>
-        <label class="form-label" for="attribute_productlist_0_{{id}}">{{lang 'products.none'}}</label>
+            <option
+                name="attribute[{{id}}]"
+                id="attribute_productlist_{{id}}_none"
+                value=""
+            >
+                {{lang 'products.none'}}
+            </option>
         {{/unless}}
         {{#each values}}
-            <input
-                class="form-radio"
-                type="radio"
+            <option
+                data-product-attribute-value="{{id}}"
+                id="attribute_productlist_{{../id}}_{{id}}"
                 name="attribute[{{../id}}]"
                 value="{{id}}"
-                id="attribute_productlist_{{../id}}_{{id}}"
-                {{#if selected}}checked{{/if}}
-                {{#if ../required}}required{{/if}}>
-            <label data-product-attribute-value="{{id}}" class="form-label" for="attribute_productlist_{{../id}}_{{id}}">{{label}}</label>
+                {{#if selected}}selected data-default{{/if}}
+                {{#if ../required}}required{{/if}}
+            >
+                {{label}}
+            </option>
         {{/each}}
-    {{/if}}
+    </select>
 </div>


### PR DESCRIPTION
Example of the code changes needed to convert the traditional Pick List modifier into a Dropdown element.