### PR TITLE
Restrict MultiLine fields from allowing more line breaks than the limit

### DIFF
--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -10,6 +10,7 @@ product:
         limit: {{theme_settings.productpage_similar_by_views_count}}
 ---
 {{inject 'productId' product.id}}
+{{inject 'graphQLToken' settings.storefront_api.token}}
 
 {{#partial "page"}}
 


### PR DESCRIPTION
Proof of concept showing theme modifications to prevent a user from being able to enter line breaks in a MultiLineTextField that exceed the limit.